### PR TITLE
Patch 2 staging

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3391,7 +3391,7 @@ else
 fi
 
 if test "$with_system_ffi" = "yes" && test -n "$PKG_CONFIG"; then
-    LIBFFI_INCLUDEDIR="`"$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//'`"
+    LIBFFI_INCLUDEDIR="`"$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ .*$//'`"
 else
     LIBFFI_INCLUDEDIR=""
 fi
@@ -5585,7 +5585,7 @@ then
 fi
 
 if test -n "$PKG_CONFIG"; then
-    NCURSESW_INCLUDEDIR="`"$PKG_CONFIG" ncursesw --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//'`"
+    NCURSESW_INCLUDEDIR="`"$PKG_CONFIG" ncursesw --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ .*$//'`"
 else
     NCURSESW_INCLUDEDIR=""
 fi
@@ -5593,9 +5593,7 @@ AC_SUBST(NCURSESW_INCLUDEDIR)
 
 # first curses header check
 ac_save_cppflags="$CPPFLAGS"
-if test "$cross_compiling" = no; then
-  CPPFLAGS="$CPPFLAGS -I$NCURSESW_INCLUDEDIR"
-fi
+CPPFLAGS="$CPPFLAGS -I$NCURSESW_INCLUDEDIR"
 
 AC_CHECK_HEADERS(curses.h ncurses.h)
 

--- a/setup.py
+++ b/setup.py
@@ -1114,8 +1114,7 @@ class PyBuildExt(build_ext):
         panel_library = 'panel'
         if curses_library == 'ncursesw':
             curses_defines.append(('HAVE_NCURSESW', '1'))
-            if not CROSS_COMPILING:
-                curses_includes.append(sysconfig.get_config_var("NCURSESW_INCLUDEDIR"))
+            curses_includes.append(sysconfig.get_config_var("NCURSESW_INCLUDEDIR"))
             # Bug 1464056: If _curses.so links with ncursesw,
             # _curses_panel.so must link with panelw.
             panel_library = 'panelw'


### PR DESCRIPTION
strip extra args from pkg-config --cflags-only-I, setup.py is only expecting a single path.

Use pkg-config ncursesw include dir even if cross-compiling (PKG_CONFIG_PATH should be set in that case).